### PR TITLE
avoid need for tx classes in native builds not using them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ on:
       - '*.adoc'
       - '*.txt'
       - '.all-contributorsrc'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/deployment/src/main/java/io/quarkiverse/messaginghub/pooled/jms/deployment/PooledJmsProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/messaginghub/pooled/jms/deployment/PooledJmsProcessor.java
@@ -4,8 +4,10 @@ import org.jboss.jandex.DotName;
 
 import io.quarkiverse.messaginghub.pooled.jms.PooledJmsDecorator;
 import io.quarkiverse.messaginghub.pooled.jms.PooledJmsRecorder;
+import io.quarkiverse.messaginghub.pooled.jms.transaction.XATransactionSupport;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
+import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.Capabilities;
 import io.quarkus.deployment.Capability;
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -43,7 +45,9 @@ class PooledJmsProcessor {
 
     @BuildStep
     void unremovableBean(BuildProducer<UnremovableBeanBuildItem> unremovableBeans) {
-        unremovableBeans
-                .produce(UnremovableBeanBuildItem.beanTypes(DotName.createSimple("org.jboss.tm.XAResourceRecoveryRegistry")));
+        if (QuarkusClassLoader.isClassPresentAtRuntime(XATransactionSupport.XA_RECOVERY_REGISTRY_CLASSNAME)) {
+            unremovableBeans.produce(UnremovableBeanBuildItem
+                    .beanTypes(DotName.createSimple(XATransactionSupport.XA_RECOVERY_REGISTRY_CLASSNAME)));
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,6 @@
     <quarkus.version>3.0.0.Final</quarkus.version>
     <quarkus-artemis.version>3.0.0</quarkus-artemis.version>
     <pooled-jms.version>3.1.0</pooled-jms.version>
-    <narayana.version>6.0.1.Final</narayana.version>
-    <jboss-transaction-spi.version>8.0.0.Final</jboss-transaction-spi.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -39,16 +37,6 @@
         <groupId>org.messaginghub</groupId>
         <artifactId>pooled-jms</artifactId>
         <version>${pooled-jms.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.narayana.jta</groupId>
-        <artifactId>narayana-jta</artifactId>
-        <version>${narayana.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss</groupId>
-        <artifactId>jboss-transaction-spi</artifactId>
-        <version>${jboss-transaction-spi.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -23,14 +23,6 @@
       <artifactId>pooled-jms</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.narayana.jta</groupId>
-      <artifactId>narayana-jta</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jboss-transaction-spi</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.graalvm.nativeimage</groupId>
       <artifactId>svm</artifactId>
       <scope>provided</scope>

--- a/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/PooledJmsWrapper.java
+++ b/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/PooledJmsWrapper.java
@@ -1,15 +1,11 @@
 package io.quarkiverse.messaginghub.pooled.jms;
 
 import jakarta.jms.ConnectionFactory;
-import jakarta.transaction.TransactionManager;
 
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.jboss.narayana.jta.jms.JmsXAResourceRecoveryHelper;
-import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.messaginghub.pooled.jms.JmsPoolConnectionFactory;
-import org.messaginghub.pooled.jms.JmsPoolXAConnectionFactory;
 
-import io.quarkus.arc.Arc;
+import io.quarkiverse.messaginghub.pooled.jms.transaction.LocalTransactionSupport;
+import io.quarkiverse.messaginghub.pooled.jms.transaction.XATransactionSupport;
 
 public class PooledJmsWrapper {
     private boolean transaction;
@@ -26,53 +22,31 @@ public class PooledJmsWrapper {
         }
 
         if (transaction && pooledJmsRuntimeConfig.transaction.equals(TransactionIntegration.XA)) {
-            return getXAConnectionFactory(connectionFactory);
+            if (XATransactionSupport.isEnabled()) {
+                return XATransactionSupport.getXAConnectionFactory(connectionFactory, pooledJmsRuntimeConfig);
+            }
+
+            throw new IllegalStateException("XA Transaction support is not available");
         } else if (transaction && pooledJmsRuntimeConfig.transaction.equals(TransactionIntegration.ENABLED)) {
-            return getLocalTransactionConnectionFactory(connectionFactory);
+            if (LocalTransactionSupport.isEnabled()) {
+                return LocalTransactionSupport.getLocalTransactionConnectionFactory(connectionFactory, pooledJmsRuntimeConfig);
+            }
+
+            throw new IllegalStateException("Local TransactionManager support is not available");
         } else {
             return getConnectionFactory(connectionFactory);
         }
     }
 
-    private ConnectionFactory getXAConnectionFactory(ConnectionFactory connectionFactory) {
-        TransactionManager transactionManager = Arc.container().instance(TransactionManager.class).get();
-
-        JmsPoolXAConnectionFactory xaConnectionFactory = new JmsPoolXAConnectionFactory();
-        xaConnectionFactory.setTransactionManager(transactionManager);
-        pooledJmsRuntimeConfigureConnectionFactory(xaConnectionFactory, connectionFactory);
-
-        XAResourceRecoveryRegistry xaResourceRecoveryRegistry = Arc.container().instance(XAResourceRecoveryRegistry.class)
-                .get();
-        boolean recoveryEnable = ConfigProvider.getConfig().getValue("quarkus.transaction-manager.enable-recovery",
-                Boolean.class);
-
-        if (xaResourceRecoveryRegistry != null && recoveryEnable) {
-            JmsXAResourceRecoveryHelper recoveryHelper = new JmsXAResourceRecoveryHelper(xaConnectionFactory);
-            xaResourceRecoveryRegistry.addXAResourceRecovery(() -> recoveryHelper.getXAResources());
-        }
-
-        return xaConnectionFactory;
-    }
-
-    private ConnectionFactory getLocalTransactionConnectionFactory(ConnectionFactory connectionFactory) {
-        TransactionManager transactionManager = Arc.container().instance(TransactionManager.class).get();
-
-        JmsPoolLocalTransactionConnectionFactory poolLocalTransactionConnectionFactory = new JmsPoolLocalTransactionConnectionFactory();
-        poolLocalTransactionConnectionFactory.setTransactionManager(transactionManager);
-        pooledJmsRuntimeConfigureConnectionFactory(poolLocalTransactionConnectionFactory, connectionFactory);
-
-        return poolLocalTransactionConnectionFactory;
-    }
-
     private ConnectionFactory getConnectionFactory(ConnectionFactory connectionFactory) {
         JmsPoolConnectionFactory poolConnectionFactory = new JmsPoolConnectionFactory();
-        pooledJmsRuntimeConfigureConnectionFactory(poolConnectionFactory, connectionFactory);
+        pooledJmsRuntimeConfigureConnectionFactory(poolConnectionFactory, connectionFactory, pooledJmsRuntimeConfig);
 
         return poolConnectionFactory;
     }
 
-    private void pooledJmsRuntimeConfigureConnectionFactory(JmsPoolConnectionFactory poolConnectionFactory,
-            ConnectionFactory connectionFactory) {
+    public static void pooledJmsRuntimeConfigureConnectionFactory(JmsPoolConnectionFactory poolConnectionFactory,
+            ConnectionFactory connectionFactory, PooledJmsRuntimeConfig pooledJmsRuntimeConfig) {
         poolConnectionFactory.setConnectionFactory(connectionFactory);
         poolConnectionFactory.setMaxConnections(pooledJmsRuntimeConfig.maxConnections);
         poolConnectionFactory.setConnectionIdleTimeout(pooledJmsRuntimeConfig.connectionIdleTimeout);

--- a/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/graal/TransactionManagerMissing.java
+++ b/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/graal/TransactionManagerMissing.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.messaginghub.pooled.jms.graal;
+
+import java.util.function.BooleanSupplier;
+
+import io.quarkiverse.messaginghub.pooled.jms.transaction.LocalTransactionSupport;
+
+public final class TransactionManagerMissing implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Class.forName(LocalTransactionSupport.TRANSACTION_MANAGER_CLASSNAME);
+            return false;
+        } catch (ClassNotFoundException e) {
+            return true;
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/graal/TransactionManagerOrRecoveryRegistryMissing.java
+++ b/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/graal/TransactionManagerOrRecoveryRegistryMissing.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.messaginghub.pooled.jms.graal;
+
+import java.util.function.BooleanSupplier;
+
+import io.quarkiverse.messaginghub.pooled.jms.transaction.LocalTransactionSupport;
+import io.quarkiverse.messaginghub.pooled.jms.transaction.XATransactionSupport;
+
+public final class TransactionManagerOrRecoveryRegistryMissing implements BooleanSupplier {
+
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Class.forName(LocalTransactionSupport.TRANSACTION_MANAGER_CLASSNAME);
+            Class.forName(XATransactionSupport.XA_RECOVERY_REGISTRY_CLASSNAME);
+            Class.forName(XATransactionSupport.JMS_XA_RESOURCE_HELPER_CLASSNAME);
+
+            return false;
+        } catch (ClassNotFoundException e) {
+            return true;
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/graal/TransactionSupportSubstitutions.java
+++ b/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/graal/TransactionSupportSubstitutions.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.messaginghub.pooled.jms.graal;
+
+import jakarta.jms.ConnectionFactory;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import io.quarkiverse.messaginghub.pooled.jms.PooledJmsRuntimeConfig;
+
+final class TransactionSupportSubstitutions {
+}
+
+/**
+ * Substitutions to disable requirement for TransactionManager classes when not needed/present.
+ */
+@TargetClass(className = "io.quarkiverse.messaginghub.pooled.jms.transaction.LocalTransactionSupport", onlyWith = TransactionManagerMissing.class)
+final class Target_io_quarkiverse_messaginghub_pooled_jms_transaction_LocalTransactionSupport {
+    @Substitute
+    public static boolean isEnabled() {
+        // Disable so Graal doesnt need to inspect the original class or need its imports/classes
+        return false;
+    }
+
+    @Substitute
+    public static ConnectionFactory getLocalTransactionConnectionFactory(ConnectionFactory connectionFactory,
+            PooledJmsRuntimeConfig pooledJmsRuntimeConfig) {
+        throw new IllegalStateException("TransactionManager not present");
+    }
+}
+
+/**
+ * Substitutions to disable requirement for TransactionManager and XA Recovery related classes when not present/needed.
+ */
+@TargetClass(className = "io.quarkiverse.messaginghub.pooled.jms.transaction.XATransactionSupport", onlyWith = TransactionManagerOrRecoveryRegistryMissing.class)
+final class Target_io_quarkiverse_messaginghub_pooled_jms_transaction_XATransactionSupport {
+    @Substitute
+    public static boolean isEnabled() {
+        // Disable so Graal doesnt need to inspect the original class or need its imports/classes
+        return false;
+    }
+
+    @Substitute
+    public static ConnectionFactory getXAConnectionFactory(ConnectionFactory connectionFactory,
+            PooledJmsRuntimeConfig pooledJmsRuntimeConfig) {
+        throw new IllegalStateException("XAResourceRecoveryRegistry not present");
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/transaction/LocalTransactionSupport.java
+++ b/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/transaction/LocalTransactionSupport.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.messaginghub.pooled.jms.transaction;
+
+import jakarta.jms.ConnectionFactory;
+
+import io.quarkiverse.messaginghub.pooled.jms.PooledJmsRuntimeConfig;
+
+public class LocalTransactionSupport {
+
+    // Classes used by XATransactionSupportIndirect that can be inspected for
+    public static final String TRANSACTION_MANAGER_CLASSNAME = "jakarta.transaction.TransactionManager";
+
+    public static boolean isEnabled() {
+        // Substitution point to allow disabling, prevent Graal inspecting unavailable classes
+        return true;
+    }
+
+    public static ConnectionFactory getLocalTransactionConnectionFactory(ConnectionFactory connectionFactory,
+            PooledJmsRuntimeConfig pooledJmsRuntimeConfig) {
+        return LocalTransactionSupportIndirect.getLocalTransactionConnectionFactory(connectionFactory, pooledJmsRuntimeConfig);
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/transaction/LocalTransactionSupportIndirect.java
+++ b/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/transaction/LocalTransactionSupportIndirect.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.messaginghub.pooled.jms.transaction;
+
+import jakarta.jms.ConnectionFactory;
+import jakarta.transaction.TransactionManager;
+
+import io.quarkiverse.messaginghub.pooled.jms.JmsPoolLocalTransactionConnectionFactory;
+import io.quarkiverse.messaginghub.pooled.jms.PooledJmsRuntimeConfig;
+import io.quarkiverse.messaginghub.pooled.jms.PooledJmsWrapper;
+import io.quarkus.arc.Arc;
+
+/* Indirects use of classes that may not be present at runtime, allows
+ * substitution in native builds to avoid using and inspecting this class
+ */
+public class LocalTransactionSupportIndirect {
+
+    public static ConnectionFactory getLocalTransactionConnectionFactory(ConnectionFactory connectionFactory,
+            PooledJmsRuntimeConfig pooledJmsRuntimeConfig) {
+        TransactionManager transactionManager = Arc.container().instance(TransactionManager.class).get();
+
+        JmsPoolLocalTransactionConnectionFactory poolLocalTransactionConnectionFactory = new JmsPoolLocalTransactionConnectionFactory();
+        poolLocalTransactionConnectionFactory.setTransactionManager(transactionManager);
+        PooledJmsWrapper.pooledJmsRuntimeConfigureConnectionFactory(poolLocalTransactionConnectionFactory, connectionFactory,
+                pooledJmsRuntimeConfig);
+
+        return poolLocalTransactionConnectionFactory;
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/transaction/XATransactionSupport.java
+++ b/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/transaction/XATransactionSupport.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.messaginghub.pooled.jms.transaction;
+
+import jakarta.jms.ConnectionFactory;
+
+import io.quarkiverse.messaginghub.pooled.jms.PooledJmsRuntimeConfig;
+
+public class XATransactionSupport {
+
+    // Classes used by PooledJmsProcessor and/or XATransactionSupportIndirect that can be inspected for
+    public static final String XA_RECOVERY_REGISTRY_CLASSNAME = "org.jboss.tm.XAResourceRecoveryRegistry";
+    public static final String JMS_XA_RESOURCE_HELPER_CLASSNAME = "org.jboss.narayana.jta.jms.JmsXAResourceRecoveryHelper";
+
+    public static boolean isEnabled() {
+        // Substitution point to allow disabling, prevent Graal inspecting unavailable classes
+        return true;
+    }
+
+    public static ConnectionFactory getXAConnectionFactory(ConnectionFactory connectionFactory,
+            PooledJmsRuntimeConfig pooledJmsRuntimeConfig) {
+        return XATransactionSupportIndirect.getXAConnectionFactory(connectionFactory, pooledJmsRuntimeConfig);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/transaction/XATransactionSupportIndirect.java
+++ b/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/transaction/XATransactionSupportIndirect.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.messaginghub.pooled.jms.transaction;
+
+import jakarta.jms.ConnectionFactory;
+import jakarta.transaction.TransactionManager;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.jboss.narayana.jta.jms.JmsXAResourceRecoveryHelper;
+import org.jboss.tm.XAResourceRecoveryRegistry;
+import org.messaginghub.pooled.jms.JmsPoolXAConnectionFactory;
+
+import io.quarkiverse.messaginghub.pooled.jms.PooledJmsRuntimeConfig;
+import io.quarkiverse.messaginghub.pooled.jms.PooledJmsWrapper;
+import io.quarkus.arc.Arc;
+
+/* Indirects use of classes that may not be present at runtime, allows
+ * substitution in native builds to avoid using and inspecting this class
+ */
+public class XATransactionSupportIndirect {
+
+    public static ConnectionFactory getXAConnectionFactory(ConnectionFactory connectionFactory,
+            PooledJmsRuntimeConfig pooledJmsRuntimeConfig) {
+        TransactionManager transactionManager = Arc.container().instance(TransactionManager.class).get();
+
+        JmsPoolXAConnectionFactory xaConnectionFactory = new JmsPoolXAConnectionFactory();
+        xaConnectionFactory.setTransactionManager(transactionManager);
+        PooledJmsWrapper.pooledJmsRuntimeConfigureConnectionFactory(xaConnectionFactory, connectionFactory,
+                pooledJmsRuntimeConfig);
+
+        XAResourceRecoveryRegistry xaResourceRecoveryRegistry = Arc.container().instance(XAResourceRecoveryRegistry.class)
+                .get();
+        boolean recoveryEnable = ConfigProvider.getConfig().getValue("quarkus.transaction-manager.enable-recovery",
+                Boolean.class);
+
+        if (xaResourceRecoveryRegistry != null && recoveryEnable) {
+            JmsXAResourceRecoveryHelper recoveryHelper = new JmsXAResourceRecoveryHelper(xaConnectionFactory);
+            xaResourceRecoveryRegistry.addXAResourceRecovery(() -> recoveryHelper.getXAResources());
+        }
+
+        return xaConnectionFactory;
+    }
+}


### PR DESCRIPTION
Alternative attempt at fixing #108. Move the XA etc related class usages into an indirect support class that can then be prevented from being reachable using substitutions when it is known those classes are not present, allowing them not to be present in those cases they were not actually going to be used.