### PR TITLE
Instead of PooledJmsRuntimeConfig, use RuntimeValue<PooledJmsRuntimeConfig> in PooledJmsRecorder.

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/PooledJmsRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/messaginghub/pooled/jms/PooledJmsRecorder.java
@@ -9,20 +9,20 @@ import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class PooledJmsRecorder {
-    private PooledJmsRuntimeConfig pooledJmsRuntimeConfig;
+    private final RuntimeValue<PooledJmsRuntimeConfig> pooledJmsRuntimeConfig;
 
-    public PooledJmsRecorder(PooledJmsRuntimeConfig config) {
+    public PooledJmsRecorder(RuntimeValue<PooledJmsRuntimeConfig> config) {
         this.pooledJmsRuntimeConfig = config;
     }
 
     public Function<ConnectionFactory, Object> getWrapper(boolean transaction) {
         return cf -> {
-            PooledJmsWrapper wrapper = new PooledJmsWrapper(transaction, pooledJmsRuntimeConfig);
+            PooledJmsWrapper wrapper = new PooledJmsWrapper(transaction, pooledJmsRuntimeConfig.getValue());
             return wrapper.wrapConnectionFactory(cf);
         };
     }
 
     public RuntimeValue<PooledJmsWrapper> getPooledJmsWrapper(boolean transaction) {
-        return new RuntimeValue<>(new PooledJmsWrapper(transaction, pooledJmsRuntimeConfig));
+        return new RuntimeValue<>(new PooledJmsWrapper(transaction, pooledJmsRuntimeConfig.getValue()));
     }
 }


### PR DESCRIPTION
This prevents the following warning from quarkus:

[WARNING] [io.quarkus.deployment] Run time configuration io.quarkiverse.messaginghub.pooled.jms.PooledJmsRuntimeConfig should be injected in a @Recorder constructor as a RuntimeValue<io.quarkiverse.messaginghub.pooled.jms.PooledJmsRuntimeConfig> at io.quarkiverse.messaginghub.pooled.jms.PooledJmsRecorder recorder of void io.quarkiverse.messaginghub.pooled.jms.deployment.PooledJmsProcessor.wrap(io.quarkus.deployment.Capabilities,io.quarkiverse.messaginghub.pooled.jms.PooledJmsRecorder,io.quarkus.deployment.annotations.BuildProducer,io.quarkus.deployment.annotations.BuildProducer) of class io.quarkiverse.messaginghub.pooled.jms.deployment.PooledJmsProcessor

Resolves #397